### PR TITLE
Remove margins for yearbook PDF

### DIFF
--- a/yearbook/yearbook.py
+++ b/yearbook/yearbook.py
@@ -11,11 +11,16 @@ HTML_TEMPLATE_DEFAULT = """
 <head>
 <meta charset='utf-8'>
 <style>
+@page {
+  size: 8.5in 11in;
+  margin: 0;
+}
 .page {
   page-break-after: always;
   width: 8.5in;
   height: 11in;
-  padding: 1in;
+  margin: 0;
+  padding: 0;
   box-sizing: border-box;
 }
 .page:last-child { page-break-after: auto; }


### PR DESCRIPTION
## Summary
- update the default HTML template for yearbook pages
- use an `@page` rule with zero margin and remove padding on `.page`

## Testing
- `python3 -m py_compile yearbook/yearbook.py`
- `pip install -r requirements.txt`
- `python3 yearbook.py examples/data.csv examples/template.html -o /tmp/yearbook.pdf --photo-base examples/images`
- `pdfinfo /tmp/yearbook.pdf | grep 'Page size'`
- `pdfinfo -box /tmp/yearbook.pdf | head -n 20`

------
https://chatgpt.com/codex/tasks/task_b_6871e31d75208325ae3c34bbca13f259