### PR TITLE
Add cross-platform GUI for photo formatting tool

### DIFF
--- a/photoformat/README.md
+++ b/photoformat/README.md
@@ -9,5 +9,10 @@ pip install -r requirements.txt
 python format.py <input_folder> <output_folder>
 ```
 
-The script will rotate images so that faces are upright, then crop them so that the detected face lies roughly in the top third of the result with a 2:3 aspect ratio (width:height).
+A small cross‑platform GUI is also available:
 
+```bash
+python gui.py
+```
+
+The script will rotate images so that faces are upright, then crop them so that the detected face lies roughly in the top third of the result with a 2:3 aspect ratio (width:height).

--- a/photoformat/gui.py
+++ b/photoformat/gui.py
@@ -1,0 +1,63 @@
+import tkinter as tk
+from tkinter import filedialog, messagebox, scrolledtext
+import threading
+import traceback
+from pathlib import Path
+
+from format import process_folder
+
+
+def run_processing(input_dir, output_dir, log_widget):
+    try:
+        process_folder(input_dir, output_dir)
+        log_widget.insert(tk.END, "Processing complete\n")
+    except Exception as e:
+        log_widget.insert(tk.END, f"Error: {e}\n")
+        log_widget.insert(tk.END, traceback.format_exc())
+        messagebox.showerror("Error", str(e))
+
+
+def start_processing(input_var, output_var, log_widget, start_button):
+    input_dir = input_var.get()
+    output_dir = output_var.get()
+    if not input_dir or not output_dir:
+        messagebox.showwarning("Missing folders", "Please select both input and output folders.")
+        return
+    start_button.config(state=tk.DISABLED)
+    log_widget.delete(1.0, tk.END)
+    thread = threading.Thread(target=lambda: [run_processing(input_dir, output_dir, log_widget), start_button.config(state=tk.NORMAL)])
+    thread.start()
+
+
+def browse_directory(variable):
+    directory = filedialog.askdirectory()
+    if directory:
+        variable.set(directory)
+
+
+def main():
+    root = tk.Tk()
+    root.title("Photo Format")
+
+    input_var = tk.StringVar()
+    output_var = tk.StringVar()
+
+    tk.Label(root, text="Input Folder:").grid(row=0, column=0, sticky="e", padx=5, pady=5)
+    tk.Entry(root, textvariable=input_var, width=40).grid(row=0, column=1, padx=5)
+    tk.Button(root, text="Browse", command=lambda: browse_directory(input_var)).grid(row=0, column=2, padx=5)
+
+    tk.Label(root, text="Output Folder:").grid(row=1, column=0, sticky="e", padx=5, pady=5)
+    tk.Entry(root, textvariable=output_var, width=40).grid(row=1, column=1, padx=5)
+    tk.Button(root, text="Browse", command=lambda: browse_directory(output_var)).grid(row=1, column=2, padx=5)
+
+    log_widget = scrolledtext.ScrolledText(root, width=60, height=15)
+    log_widget.grid(row=2, column=0, columnspan=3, padx=5, pady=5)
+
+    start_button = tk.Button(root, text="Run", command=lambda: start_processing(input_var, output_var, log_widget, start_button))
+    start_button.grid(row=3, column=1, pady=10)
+
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a simple Tkinter-based GUI to select folders and run `format.py`
- document how to launch the GUI in the `photoformat` README

## Testing
- `python -m py_compile photoformat/format.py photoformat/gui.py`

------
https://chatgpt.com/codex/tasks/task_b_6872724d0940832583d89e3980c109cd