### PR TITLE
Add GUIs for photorename and yearbook

### DIFF
--- a/photorename/README.md
+++ b/photorename/README.md
@@ -10,6 +10,12 @@ sudo apt-get install -y tesseract-ocr
 python rename.py names.csv /path/to/input_photos /path/to/output_photos
 ```
 
+A small cross‑platform GUI is also available:
+
+```bash
+python gui.py
+```
+
 The script expects `names.csv` to contain a column called `name`.  It looks for
 badge photos where the badge text matches one of these names.  When a badge is
 found the following five photos are scanned for additional pictures of the same

--- a/photorename/gui.py
+++ b/photorename/gui.py
@@ -1,0 +1,108 @@
+import tkinter as tk
+from tkinter import filedialog, messagebox, scrolledtext
+import threading
+import traceback
+
+from rename import process_images
+
+
+def run_processing(spreadsheet, input_dir, output_dir, unmatched_dir, log_widget):
+    try:
+        process_images(spreadsheet, input_dir, output_dir, unmatched_dir)
+        log_widget.insert(tk.END, "Processing complete\n")
+    except Exception as e:
+        log_widget.insert(tk.END, f"Error: {e}\n")
+        log_widget.insert(tk.END, traceback.format_exc())
+        messagebox.showerror("Error", str(e))
+
+
+def start_processing(spreadsheet_var, input_var, output_var, unmatched_var,
+                      log_widget, start_button):
+    spreadsheet = spreadsheet_var.get()
+    input_dir = input_var.get()
+    output_dir = output_var.get()
+    unmatched_dir = unmatched_var.get() or 'unmatched'
+    if not spreadsheet or not input_dir or not output_dir:
+        messagebox.showwarning(
+            "Missing fields",
+            "Please select spreadsheet, input and output folders.")
+        return
+    start_button.config(state=tk.DISABLED)
+    log_widget.delete(1.0, tk.END)
+    thread = threading.Thread(target=lambda: [
+        run_processing(spreadsheet, input_dir, output_dir, unmatched_dir,
+                       log_widget),
+        start_button.config(state=tk.NORMAL)
+    ])
+    thread.start()
+
+
+def browse_file(variable):
+    path = filedialog.askopenfilename()
+    if path:
+        variable.set(path)
+
+
+def browse_directory(variable):
+    directory = filedialog.askdirectory()
+    if directory:
+        variable.set(directory)
+
+
+def main():
+    root = tk.Tk()
+    root.title("Photo Rename")
+
+    spreadsheet_var = tk.StringVar()
+    input_var = tk.StringVar()
+    output_var = tk.StringVar()
+    unmatched_var = tk.StringVar()
+
+    tk.Label(root, text="Spreadsheet:").grid(row=0, column=0, sticky="e", padx=5,
+                                               pady=5)
+    tk.Entry(root, textvariable=spreadsheet_var, width=40).grid(row=0, column=1,
+                                                                padx=5)
+    tk.Button(root, text="Browse",
+              command=lambda: browse_file(spreadsheet_var)).grid(row=0, column=2,
+                                                                padx=5)
+
+    tk.Label(root, text="Input Folder:").grid(row=1, column=0, sticky="e", padx=5,
+                                               pady=5)
+    tk.Entry(root, textvariable=input_var, width=40).grid(row=1, column=1, padx=5)
+    tk.Button(root, text="Browse",
+              command=lambda: browse_directory(input_var)).grid(row=1, column=2,
+                                                                padx=5)
+
+    tk.Label(root, text="Output Folder:").grid(row=2, column=0, sticky="e",
+                                                padx=5, pady=5)
+    tk.Entry(root, textvariable=output_var, width=40).grid(row=2, column=1,
+                                                           padx=5)
+    tk.Button(root, text="Browse",
+              command=lambda: browse_directory(output_var)).grid(row=2, column=2,
+                                                                 padx=5)
+
+    tk.Label(root, text="Unmatched Folder:").grid(row=3, column=0, sticky="e",
+                                                   padx=5, pady=5)
+    tk.Entry(root, textvariable=unmatched_var, width=40).grid(row=3, column=1,
+                                                             padx=5)
+    tk.Button(root, text="Browse",
+              command=lambda: browse_directory(unmatched_var)).grid(row=3,
+                                                                    column=2,
+                                                                    padx=5)
+
+    log_widget = scrolledtext.ScrolledText(root, width=60, height=15)
+    log_widget.grid(row=4, column=0, columnspan=3, padx=5, pady=5)
+
+    start_button = tk.Button(
+        root,
+        text="Run",
+        command=lambda: start_processing(spreadsheet_var, input_var, output_var,
+                                         unmatched_var, log_widget, start_button)
+    )
+    start_button.grid(row=5, column=1, pady=10)
+
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/photorename/rename.py
+++ b/photorename/rename.py
@@ -173,13 +173,13 @@ def finalize_unmatched(images, used, unmatched_dir):
             print(f'Unmatched {img_path.name}')
             shutil.copy(img_path, unmatched_dir / img_path.name)
 
-def main():
-    args = parse_args()
-    names = read_names(Path(args.spreadsheet))
+def process_images(spreadsheet, input_dir, output_dir, unmatched_dir='unmatched'):
+    """Run the renaming process without using CLI arguments."""
+    names = read_names(Path(spreadsheet))
 
-    input_dir = Path(args.input_dir)
-    output_dir = Path(args.output_dir)
-    unmatched_dir = Path(args.unmatched_dir)
+    input_dir = Path(input_dir)
+    output_dir = Path(output_dir)
+    unmatched_dir = Path(unmatched_dir)
 
     output_dir.mkdir(parents=True, exist_ok=True)
     unmatched_dir.mkdir(parents=True, exist_ok=True)
@@ -213,6 +213,12 @@ def main():
                         unmatched_dir, used, badge_counts)
 
     finalize_unmatched(images, used, unmatched_dir)
+
+
+def main():
+    args = parse_args()
+    process_images(args.spreadsheet, args.input_dir,
+                   args.output_dir, args.unmatched_dir)
 
 if __name__ == '__main__':
     main()

--- a/yearbook/README.md
+++ b/yearbook/README.md
@@ -1,0 +1,16 @@
+# Yearbook
+
+This folder contains a small script to generate a PDF yearbook from a CSV file and an HTML Mustache template.
+
+## Usage
+
+```bash
+pip install -r requirements.txt
+python yearbook.py data.csv template.html -o output.pdf
+```
+
+A basic cross‑platform GUI is also available:
+
+```bash
+python gui.py
+```

--- a/yearbook/gui.py
+++ b/yearbook/gui.py
@@ -1,0 +1,119 @@
+import tkinter as tk
+from tkinter import filedialog, messagebox, scrolledtext
+import threading
+import traceback
+
+from yearbook import generate_pdf, render_pages
+import pandas as pd
+
+
+def run_processing(spreadsheet, template, output_path, photo_base, log_widget):
+    try:
+        df = pd.read_csv(spreadsheet)
+        with open(template, 'r', encoding='utf-8') as f:
+            template_str = f.read()
+        pages = render_pages(df, template_str, photo_base)
+        generate_pdf(pages, output_path)
+        log_widget.insert(tk.END, f"Generated {output_path}\n")
+    except Exception as e:
+        log_widget.insert(tk.END, f"Error: {e}\n")
+        log_widget.insert(tk.END, traceback.format_exc())
+        messagebox.showerror("Error", str(e))
+
+
+def start_processing(spreadsheet_var, template_var, output_var, photo_base_var,
+                      log_widget, start_button):
+    spreadsheet = spreadsheet_var.get()
+    template = template_var.get()
+    output_path = output_var.get() or 'yearbook.pdf'
+    photo_base = photo_base_var.get()
+    if not spreadsheet or not template:
+        messagebox.showwarning(
+            "Missing fields", "Please select spreadsheet and template files.")
+        return
+    start_button.config(state=tk.DISABLED)
+    log_widget.delete(1.0, tk.END)
+    thread = threading.Thread(target=lambda: [
+        run_processing(spreadsheet, template, output_path, photo_base, log_widget),
+        start_button.config(state=tk.NORMAL)
+    ])
+    thread.start()
+
+
+def browse_file(variable):
+    path = filedialog.askopenfilename()
+    if path:
+        variable.set(path)
+
+
+def browse_save_file(variable):
+    path = filedialog.asksaveasfilename(defaultextension='.pdf',
+                                        filetypes=[('PDF files', '*.pdf')])
+    if path:
+        variable.set(path)
+
+
+def browse_directory(variable):
+    directory = filedialog.askdirectory()
+    if directory:
+        variable.set(directory)
+
+
+def main():
+    root = tk.Tk()
+    root.title("Yearbook")
+
+    spreadsheet_var = tk.StringVar()
+    template_var = tk.StringVar()
+    output_var = tk.StringVar(value='yearbook.pdf')
+    photo_base_var = tk.StringVar()
+
+    tk.Label(root, text="Spreadsheet:").grid(row=0, column=0, sticky="e", padx=5,
+                                               pady=5)
+    tk.Entry(root, textvariable=spreadsheet_var, width=40).grid(row=0, column=1,
+                                                                padx=5)
+    tk.Button(root, text="Browse",
+              command=lambda: browse_file(spreadsheet_var)).grid(row=0, column=2,
+                                                                padx=5)
+
+    tk.Label(root, text="Template:").grid(row=1, column=0, sticky="e", padx=5,
+                                           pady=5)
+    tk.Entry(root, textvariable=template_var, width=40).grid(row=1, column=1,
+                                                             padx=5)
+    tk.Button(root, text="Browse",
+              command=lambda: browse_file(template_var)).grid(row=1, column=2,
+                                                              padx=5)
+
+    tk.Label(root, text="Output PDF:").grid(row=2, column=0, sticky="e", padx=5,
+                                             pady=5)
+    tk.Entry(root, textvariable=output_var, width=40).grid(row=2, column=1,
+                                                           padx=5)
+    tk.Button(root, text="Browse",
+              command=lambda: browse_save_file(output_var)).grid(row=2, column=2,
+                                                                 padx=5)
+
+    tk.Label(root, text="Photo Base:").grid(row=3, column=0, sticky="e", padx=5,
+                                             pady=5)
+    tk.Entry(root, textvariable=photo_base_var, width=40).grid(row=3, column=1,
+                                                               padx=5)
+    tk.Button(root, text="Browse",
+              command=lambda: browse_directory(photo_base_var)).grid(row=3,
+                                                                    column=2,
+                                                                    padx=5)
+
+    log_widget = scrolledtext.ScrolledText(root, width=60, height=15)
+    log_widget.grid(row=4, column=0, columnspan=3, padx=5, pady=5)
+
+    start_button = tk.Button(
+        root,
+        text="Run",
+        command=lambda: start_processing(spreadsheet_var, template_var, output_var,
+                                         photo_base_var, log_widget, start_button)
+    )
+    start_button.grid(row=5, column=1, pady=10)
+
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `process_images` helper to photorename
- provide Tkinter UI for photorename
- mention GUI in photorename README
- add README for yearbook with GUI instructions
- provide Tkinter UI for yearbook

## Testing
- `python -m py_compile photorename/gui.py photorename/rename.py yearbook/gui.py yearbook/yearbook.py`

------
https://chatgpt.com/codex/tasks/task_b_68728302541483259eef758f472c4076