### PR TITLE
Extend yearbook multi-profile feature

### DIFF
--- a/yearbook/README.md
+++ b/yearbook/README.md
@@ -7,9 +7,13 @@ This folder contains a small script to generate a PDF yearbook from a CSV file a
 ```bash
 pip install -r requirements.txt
 python yearbook.py data.csv template.html -o output.pdf
+
+# Render two people per page
+python yearbook.py data.csv template_2.html --per-page 2 -o output2.pdf
 ```
 
-A basic cross‑platform GUI is also available:
+A basic cross‑platform GUI is also available. It now includes a field to set how
+many profiles appear on each page:
 
 ```bash
 python gui.py

--- a/yearbook/examples/template_2.html
+++ b/yearbook/examples/template_2.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  body { font-family: sans-serif; margin: 0; padding: 10px; background-color: grey; }
+  .profile { display: flex; flex-direction: row; margin-bottom: 20px; }
+  .profile img { width: 200px; height: 300px; flex: 0; }
+  .profile .info { margin-left: 10px; flex: 1; }
+</style>
+</head>
+<body>
+  <div class="profile">
+    <img src="{{photo1}}">
+    <div class="info">
+      <h1>{{name1}}</h1>
+      <p class="quote">"{{quote1}}"</p>
+      <p><strong>Home Town:</strong> {{hometown1}}</p>
+      <p><strong>Birthday:</strong> {{birthday1}}</p>
+    </div>
+  </div>
+  <div class="profile">
+    <img src="{{photo2}}">
+    <div class="info">
+      <h1>{{name2}}</h1>
+      <p class="quote">"{{quote2}}"</p>
+      <p><strong>Home Town:</strong> {{hometown2}}</p>
+      <p><strong>Birthday:</strong> {{birthday2}}</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/yearbook/examples/template_3.html
+++ b/yearbook/examples/template_3.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  body { font-family: sans-serif; margin: 0; padding: 10px; background-color: grey; }
+  .profile { display: flex; flex-direction: row; margin-bottom: 15px; }
+  .profile img { width: 150px; height: 225px; flex: 0; }
+  .profile .info { margin-left: 10px; flex: 1; }
+</style>
+</head>
+<body>
+  <div class="profile">
+    <img src="{{photo1}}">
+    <div class="info">
+      <h1>{{name1}}</h1>
+      <p class="quote">"{{quote1}}"</p>
+      <p><strong>Home Town:</strong> {{hometown1}}</p>
+      <p><strong>Birthday:</strong> {{birthday1}}</p>
+    </div>
+  </div>
+  <div class="profile">
+    <img src="{{photo2}}">
+    <div class="info">
+      <h1>{{name2}}</h1>
+      <p class="quote">"{{quote2}}"</p>
+      <p><strong>Home Town:</strong> {{hometown2}}</p>
+      <p><strong>Birthday:</strong> {{birthday2}}</p>
+    </div>
+  </div>
+  <div class="profile">
+    <img src="{{photo3}}">
+    <div class="info">
+      <h1>{{name3}}</h1>
+      <p class="quote">"{{quote3}}"</p>
+      <p><strong>Home Town:</strong> {{hometown3}}</p>
+      <p><strong>Birthday:</strong> {{birthday3}}</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/yearbook/gui.py
+++ b/yearbook/gui.py
@@ -7,12 +7,13 @@ from yearbook import generate_pdf, render_pages
 import pandas as pd
 
 
-def run_processing(spreadsheet, template, output_path, photo_base, log_widget):
+def run_processing(spreadsheet, template, output_path, photo_base, per_page,
+                   log_widget):
     try:
         df = pd.read_csv(spreadsheet)
         with open(template, 'r', encoding='utf-8') as f:
             template_str = f.read()
-        pages = render_pages(df, template_str, photo_base)
+        pages = render_pages(df, template_str, photo_base, per_page)
         generate_pdf(pages, output_path)
         log_widget.insert(tk.END, f"Generated {output_path}\n")
     except Exception as e:
@@ -22,11 +23,12 @@ def run_processing(spreadsheet, template, output_path, photo_base, log_widget):
 
 
 def start_processing(spreadsheet_var, template_var, output_var, photo_base_var,
-                      log_widget, start_button):
+                      per_page_var, log_widget, start_button):
     spreadsheet = spreadsheet_var.get()
     template = template_var.get()
     output_path = output_var.get() or 'yearbook.pdf'
     photo_base = photo_base_var.get()
+    per_page = per_page_var.get() or 1
     if not spreadsheet or not template:
         messagebox.showwarning(
             "Missing fields", "Please select spreadsheet and template files.")
@@ -34,7 +36,8 @@ def start_processing(spreadsheet_var, template_var, output_var, photo_base_var,
     start_button.config(state=tk.DISABLED)
     log_widget.delete(1.0, tk.END)
     thread = threading.Thread(target=lambda: [
-        run_processing(spreadsheet, template, output_path, photo_base, log_widget),
+        run_processing(spreadsheet, template, output_path, photo_base,
+                       per_page, log_widget),
         start_button.config(state=tk.NORMAL)
     ])
     thread.start()
@@ -67,6 +70,7 @@ def main():
     template_var = tk.StringVar()
     output_var = tk.StringVar(value='yearbook.pdf')
     photo_base_var = tk.StringVar()
+    per_page_var = tk.IntVar(value=1)
 
     tk.Label(root, text="Spreadsheet:").grid(row=0, column=0, sticky="e", padx=5,
                                                pady=5)
@@ -101,16 +105,22 @@ def main():
                                                                     column=2,
                                                                     padx=5)
 
+    tk.Label(root, text="Profiles per Page:").grid(row=4, column=0, sticky="e",
+                                                    padx=5, pady=5)
+    tk.Entry(root, textvariable=per_page_var, width=40).grid(row=4, column=1,
+                                                             padx=5)
+
     log_widget = scrolledtext.ScrolledText(root, width=60, height=15)
-    log_widget.grid(row=4, column=0, columnspan=3, padx=5, pady=5)
+    log_widget.grid(row=5, column=0, columnspan=3, padx=5, pady=5)
 
     start_button = tk.Button(
         root,
         text="Run",
         command=lambda: start_processing(spreadsheet_var, template_var, output_var,
-                                         photo_base_var, log_widget, start_button)
+                                         photo_base_var, per_page_var, log_widget,
+                                         start_button)
     )
-    start_button.grid(row=5, column=1, pady=10)
+    start_button.grid(row=6, column=1, pady=10)
 
     root.mainloop()
 

--- a/yearbook/yearbook.py
+++ b/yearbook/yearbook.py
@@ -37,16 +37,44 @@ HTML_TEMPLATE_DEFAULT = """
 """
 
 
-def render_pages(dataframe, template_str, photo_base):
+def render_pages(dataframe, template_str, photo_base, per_page=1):
+    """Render a list of HTML pages from the dataframe.
+
+    ``per_page`` specifies how many profiles should be rendered on a single
+    page of the output. Template variables are suffixed with the position
+    number starting at 1 (e.g. ``name1``, ``name2``) to reference the correct
+    profile.
+    """
+
     renderer = pystache.Renderer()
     pages = []
+
+    batch = []
     for _, row in dataframe.iterrows():
-        context = row.to_dict()
-        if photo_base:
-            path = os.path.join(photo_base, str(row.get('photo', '')))
-            context['photo'] = os.path.abspath(path)
+        batch.append(row)
+        if len(batch) == per_page:
+            context = {}
+            for idx, r in enumerate(batch, start=1):
+                for key, value in r.to_dict().items():
+                    if photo_base and key == 'photo':
+                        path = os.path.join(photo_base, str(value))
+                        value = os.path.abspath(path)
+                    context[f"{key}{idx}"] = value
+            html = renderer.render(template_str, context)
+            pages.append({'html': html})
+            batch = []
+
+    if batch:
+        context = {}
+        for idx, r in enumerate(batch, start=1):
+            for key, value in r.to_dict().items():
+                if photo_base and key == 'photo':
+                    path = os.path.join(photo_base, str(value))
+                    value = os.path.abspath(path)
+                context[f"{key}{idx}"] = value
         html = renderer.render(template_str, context)
         pages.append({'html': html})
+
     return pages
 
 
@@ -60,14 +88,18 @@ def main():
     parser = argparse.ArgumentParser(description='Generate yearbook PDF from spreadsheet and template.')
     parser.add_argument('spreadsheet', help='CSV file with columns name, quote, home town, birthday, photo')
     parser.add_argument('template', help='Mustache HTML template for a single page')
-    parser.add_argument('-o', '--output', default='yearbook.pdf', help='Output PDF file path')
-    parser.add_argument('--photo-base', default='', help='Base path or URL prefix for photos')
+    parser.add_argument('-o', '--output', default='yearbook.pdf',
+                        help='Output PDF file path')
+    parser.add_argument('--photo-base', default='',
+                        help='Base path or URL prefix for photos')
+    parser.add_argument('--per-page', type=int, default=1,
+                        help='Number of profiles to render per page')
     args = parser.parse_args()
 
     df = pd.read_csv(args.spreadsheet)
     with open(args.template, 'r', encoding='utf-8') as f:
         template_str = f.read()
-    pages = render_pages(df, template_str, args.photo_base)
+    pages = render_pages(df, template_str, args.photo_base, args.per_page)
     generate_pdf(pages, args.output)
     print(f'Generated {args.output} with {len(pages)} pages.')
 


### PR DESCRIPTION
## Summary
- render multiple profiles on a single page
- add `--per-page` option to CLI
- update GUI with profiles-per-page field
- add example templates for 2 or 3 profiles per page
- document new option in README

## Testing
- `python -m pip install -r yearbook/requirements.txt`
- `python yearbook/yearbook.py yearbook/examples/data.csv yearbook/examples/template_2.html --photo-base yearbook/examples/images --per-page 2 -o yearbook/examples/output2.pdf`
- `python yearbook/yearbook.py yearbook/examples/data.csv yearbook/examples/template_3.html --photo-base yearbook/examples/images --per-page 3 -o yearbook/examples/output3.pdf`
- `python yearbook/yearbook.py yearbook/examples/data.csv yearbook/examples/template.html --photo-base yearbook/examples/images -o yearbook/examples/output.pdf`


------
https://chatgpt.com/codex/tasks/task_b_687285bd62d88325916bbea41ead5098