### PR TITLE
Enhance photo rename script

### DIFF
--- a/photorename/README.md
+++ b/photorename/README.md
@@ -10,14 +10,24 @@ sudo apt-get install -y tesseract-ocr
 python rename.py names.csv /path/to/input_photos /path/to/output_photos
 ```
 
+Optional arguments:
+
+```
+--first_last      spreadsheet uses first and last name columns instead of a single name column
+--skip_rows N     skip the first N rows in the spreadsheet
+```
+
 A small cross‑platform GUI is also available:
 
 ```bash
 python gui.py
 ```
 
-The script expects `names.csv` to contain a column called `name`.  It looks for
-badge photos where the badge text matches one of these names.  When a badge is
+The script expects `names.csv` to contain a column called `name` by default.
+With the `--first_last` option, the first two columns are treated as first and
+last names instead.  Use `--skip_rows N` to ignore header lines or other data at
+the top of the sheet.  The script looks for badge photos where the badge text
+matches one of these names.  When a badge is
 found the following five photos are scanned for additional pictures of the same
 person without the badge using a simple face comparison based on OpenCV.  The matched images are copied
 to the output directory and renamed as described in the script.

--- a/photorename/gui.py
+++ b/photorename/gui.py
@@ -6,9 +6,11 @@ import traceback
 from rename import process_images
 
 
-def run_processing(spreadsheet, input_dir, output_dir, unmatched_dir, log_widget):
+def run_processing(spreadsheet, input_dir, output_dir, unmatched_dir, first_last,
+                   skip_rows, log_widget):
     try:
-        process_images(spreadsheet, input_dir, output_dir, unmatched_dir)
+        process_images(spreadsheet, input_dir, output_dir, unmatched_dir,
+                       first_last=first_last, skip_rows=skip_rows)
         log_widget.insert(tk.END, "Processing complete\n")
     except Exception as e:
         log_widget.insert(tk.END, f"Error: {e}\n")
@@ -17,11 +19,13 @@ def run_processing(spreadsheet, input_dir, output_dir, unmatched_dir, log_widget
 
 
 def start_processing(spreadsheet_var, input_var, output_var, unmatched_var,
-                      log_widget, start_button):
+                      first_last_var, skip_var, log_widget, start_button):
     spreadsheet = spreadsheet_var.get()
     input_dir = input_var.get()
     output_dir = output_var.get()
     unmatched_dir = unmatched_var.get() or 'unmatched'
+    first_last = first_last_var.get()
+    skip_rows = skip_var.get()
     if not spreadsheet or not input_dir or not output_dir:
         messagebox.showwarning(
             "Missing fields",
@@ -31,8 +35,8 @@ def start_processing(spreadsheet_var, input_var, output_var, unmatched_var,
     log_widget.delete(1.0, tk.END)
     thread = threading.Thread(target=lambda: [
         run_processing(spreadsheet, input_dir, output_dir, unmatched_dir,
-                       log_widget),
-        start_button.config(state=tk.NORMAL)
+                       first_last, skip_rows, log_widget),
+                       start_button.config(state=tk.NORMAL)
     ])
     thread.start()
 
@@ -57,6 +61,8 @@ def main():
     input_var = tk.StringVar()
     output_var = tk.StringVar()
     unmatched_var = tk.StringVar()
+    first_last_var = tk.BooleanVar()
+    skip_var = tk.IntVar(value=0)
 
     tk.Label(root, text="Spreadsheet:").grid(row=0, column=0, sticky="e", padx=5,
                                                pady=5)
@@ -90,16 +96,25 @@ def main():
                                                                     column=2,
                                                                     padx=5)
 
+    tk.Checkbutton(root, text="First + Last columns", variable=first_last_var).grid(
+        row=4, column=0, columnspan=3, sticky="w", padx=5, pady=5)
+
+    tk.Label(root, text="Skip Rows:").grid(row=5, column=0, sticky="e", padx=5,
+                                            pady=5)
+    tk.Spinbox(root, from_=0, to=1000, textvariable=skip_var,
+               width=5).grid(row=5, column=1, sticky="w", padx=5)
+
     log_widget = scrolledtext.ScrolledText(root, width=60, height=15)
-    log_widget.grid(row=4, column=0, columnspan=3, padx=5, pady=5)
+    log_widget.grid(row=6, column=0, columnspan=3, padx=5, pady=5)
 
     start_button = tk.Button(
         root,
         text="Run",
         command=lambda: start_processing(spreadsheet_var, input_var, output_var,
-                                         unmatched_var, log_widget, start_button)
+                                         unmatched_var, first_last_var, skip_var,
+                                         log_widget, start_button)
     )
-    start_button.grid(row=5, column=1, pady=10)
+    start_button.grid(row=7, column=1, pady=10)
 
     root.mainloop()
 


### PR DESCRIPTION
## Summary
- add `--first_last` and `--skip_rows` options to the renaming script
- support split first/last name columns when reading the spreadsheet
- expose new options in the GUI
- document new functionality in README

## Testing
- `python -m py_compile photorename/rename.py photorename/gui.py`

------
https://chatgpt.com/codex/tasks/task_b_68743c5cb580832590913338ca653a15