### PR TITLE
Add badge cropping script

### DIFF
--- a/badgebot/README.md
+++ b/badgebot/README.md
@@ -1,0 +1,12 @@
+# Badge Crop
+
+This script detects a white rectangular badge in a photo and crops the image to that badge. It is useful when people hold up name tags or cards that should be isolated.
+
+## Usage
+
+```bash
+pip install -r requirements.txt
+python crop.py input.jpg -o badge.jpg
+```
+
+If no badge is detected, the script prints a message and no file is written.

--- a/badgebot/crop.py
+++ b/badgebot/crop.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Crop a white rectangular badge from an image if present."""
+
+import argparse
+from pathlib import Path
+import cv2
+import numpy as np
+
+
+def find_badge(image: np.ndarray):
+    """Return bounding box (x, y, w, h) of the most likely badge or None."""
+    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    blur = cv2.GaussianBlur(gray, (5, 5), 0)
+    # threshold for bright regions
+    _, thresh = cv2.threshold(blur, 200, 255, cv2.THRESH_BINARY)
+    kernel = np.ones((5, 5), np.uint8)
+    thresh = cv2.morphologyEx(thresh, cv2.MORPH_CLOSE, kernel)
+    contours, _ = cv2.findContours(thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+
+    img_area = image.shape[0] * image.shape[1]
+    best_rect = None
+    best_area = 0
+    for cnt in contours:
+        area = cv2.contourArea(cnt)
+        if area < img_area * 0.01:
+            continue
+        peri = cv2.arcLength(cnt, True)
+        approx = cv2.approxPolyDP(cnt, 0.02 * peri, True)
+        if len(approx) == 4:
+            x, y, w, h = cv2.boundingRect(approx)
+            if area > best_area:
+                best_area = area
+                best_rect = (x, y, w, h)
+    return best_rect
+
+
+def crop_badge(image: np.ndarray):
+    rect = find_badge(image)
+    if rect is None:
+        return None
+    x, y, w, h = rect
+    return image[y : y + h, x : x + w]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Crop white badge from an image if found")
+    parser.add_argument("image", help="Input image path")
+    parser.add_argument("-o", "--output", default="badge.jpeg", help="Output file path")
+    args = parser.parse_args()
+
+    img = cv2.imread(args.image)
+    if img is None:
+        parser.error(f"Could not read {args.image}")
+
+    badge = crop_badge(img)
+    if badge is None:
+        print("No badge detected")
+        return
+    cv2.imwrite(args.output, badge)
+    print(f"Saved badge crop to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/badgebot/requirements.txt
+++ b/badgebot/requirements.txt
@@ -1,0 +1,1 @@
+opencv-python


### PR DESCRIPTION
## Summary
- add `badgebot/crop.py` to automatically crop white rectangular badges from photos
- document usage in `badgebot/README.md`
- specify `opencv-python` dependency

## Testing
- `python -m py_compile badgebot/crop.py`
- `pip install -r badgebot/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_b_6875b60cf0b88325b460219805f95433